### PR TITLE
Drop BRANCH from FreeBSD-base url

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -132,7 +132,7 @@ make_workdir() {
 # FreeBSD pkgbase repo for building the images
 
 FreeBSD-base: {
-  url: "${REPOURL}/${BRANCH}/\${ABI}/latest",
+  url: "${REPOURL}/\${ABI}/latest",
   signature_type: "none",
   pubkey: "/usr/local/etc/ssl/pkgbase.pub",
   enabled: yes


### PR DESCRIPTION
After following the instructions in https://wiki.freebsd.org/PkgBase to build up the packages locally (`buildworld`, `buildkernel`, `packages`) and setting up `nginx` - there is a discrepancy between how the packages are installed in `/usr/obj/usr/src/repo/` and served out via `nginx` and what the generated `base.conf` file was giving over to `pkg` for fetching the packages.

