### PR TITLE
Fix running of /usr/bin/login

### DIFF
--- a/build-small.sh
+++ b/build-small.sh
@@ -20,7 +20,7 @@ parse_args "$@"
 
 if [ ${BUILD} = yes ]; then
     build_image minimal small "" fixup \
-		FreeBSD-utilities
+		FreeBSD-utilities FreeBSD-libbsm
 fi
 if [ ${PUSH} = yes ]; then
     push_image small


### PR DESCRIPTION
before:
```bash
ld-elf.so.1: Shared object "libbsm.so.3" not found, required by "login"
```

after:
```bash
root@84d1efecc992:~ #
```